### PR TITLE
Support E.ON meter exports; make fixed monthly fees optional

### DIFF
--- a/frontend/scripts/test-analyze.mjs
+++ b/frontend/scripts/test-analyze.mjs
@@ -734,5 +734,110 @@ console.log("Test 20: drop data before 2025-10-01");
   eq(allBefore.droppedRows, 1, "all-before: 1 dropped");
 }
 
+// --- Test 21: E.ON "Mätvärdesexport" CSV (metadata preamble + start/end + direction) ---
+console.log("Test 21: E.ON Mätvärdesexport format");
+{
+  const eon = [
+    "﻿Anläggnings-id;Tidpunkt för export;Energiprodukt;Starttidpunkt;Sluttidpunkt;Måttenhet",
+    "735999114013307011;2026-07-30 12:57:06;Aktiv energi;2025-10-01 00:00:00;2025-10-01 01:00:00;kWh",
+    "",
+    "Starttidpunkt;Sluttidpunkt;Energiriktning;Kvalitet;Kvantitet",
+    "2025-10-01 00:00:00;2025-10-01 00:15:00;Produktion;Uppmätt;0,100",
+    "2025-10-01 00:15:00;2025-10-01 00:30:00;Produktion;Uppmätt;0,200",
+    "2025-10-01 00:30:00;2025-10-01 00:45:00;Produktion;Uppmätt;0,300",
+    "2025-10-01 00:45:00;2025-10-01 01:00:00;Produktion;Uppmätt;0,400",
+  ].join("\n");
+  const p = parseProductionCsv(eon);
+  eq(p.rows.length, 4, "eon: metadata preamble skipped, 4 data rows");
+  eq(p.datetimeColumn, "Starttidpunkt", "eon: datetime column from the real header");
+  eq(p.productionColumn, "Kvantitet", "eon: value column is Kvantitet, not Energiriktning");
+  eq(p.granularity, "15min", "eon: 15-min granularity");
+  eq(p.stepMinutes, 15, "eon: step from declared start/end");
+  approx(p.rows.reduce((s, r) => s + r.kwh, 0), 1.0, "eon: total kWh");
+  approx(p.rows[0].end - p.rows[0].start, 15 * 60 * 1000, "eon: interval end taken from Sluttidpunkt");
+  eq(assessResolution(p).isQuarterHour, true, "eon: passes 15-min validation");
+
+  // Mixed-direction export: consumption rows must not be summed into production.
+  const mixed = [
+    "Starttidpunkt;Sluttidpunkt;Energiriktning;Kvalitet;Kvantitet",
+    "2025-10-01 00:00:00;2025-10-01 00:15:00;Produktion;Uppmätt;1,000",
+    "2025-10-01 00:00:00;2025-10-01 00:15:00;Förbrukning;Uppmätt;9,000",
+    "2025-10-01 00:15:00;2025-10-01 00:30:00;Produktion;Uppmätt;2,000",
+    "2025-10-01 00:15:00;2025-10-01 00:30:00;Förbrukning;Uppmätt;9,000",
+  ].join("\n");
+  const pm = parseProductionCsv(mixed);
+  eq(pm.rows.length, 2, "eon mixed: consumption rows filtered out");
+  approx(pm.rows.reduce((s, r) => s + r.kwh, 0), 3.0, "eon mixed: only production summed");
+
+  // Unit declared in the metadata block rather than the value column header.
+  const mwh = [
+    "Anläggnings-id;Måttenhet",
+    "735999;MWh",
+    "",
+    "Starttidpunkt;Sluttidpunkt;Energiriktning;Kvalitet;Kvantitet",
+    "2025-10-01 00:00:00;2025-10-01 00:15:00;Produktion;Uppmätt;1,000",
+    "2025-10-01 00:15:00;2025-10-01 00:30:00;Produktion;Uppmätt;2,000",
+  ].join("\n");
+  approx(
+    parseProductionCsv(mwh).rows.reduce((s, r) => s + r.kwh, 0),
+    3000,
+    "eon: MWh from metadata converted to kWh"
+  );
+
+  // Spring-forward DST: E.ON writes 01:45 -> 03:00 for one quarter (wall clock jumps).
+  const dst = [
+    "Starttidpunkt;Sluttidpunkt;Energiriktning;Kvalitet;Kvantitet",
+    "2026-03-29 01:15:00;2026-03-29 01:30:00;Produktion;Uppmätt;1,000",
+    "2026-03-29 01:30:00;2026-03-29 01:45:00;Produktion;Uppmätt;1,000",
+    "2026-03-29 01:45:00;2026-03-29 03:00:00;Produktion;Uppmätt;1,000",
+    "2026-03-29 03:00:00;2026-03-29 03:15:00;Produktion;Uppmätt;1,000",
+  ].join("\n");
+  const pd = parseProductionCsv(dst);
+  const lengths = [...new Set(pd.rows.map((r) => (r.end - r.start) / 60000))];
+  eq(lengths.length, 1, "eon DST: no over-long interval survives");
+  eq(lengths[0], 15, "eon DST: 75-minute wall-clock gap capped to the 15-min step");
+}
+
+// --- Test 22: fixed monthly fees are optional -> smaller report ---
+console.log("Test 22: optional fixed monthly fees");
+{
+  const prod = [];
+  const prices = [];
+  // One full month of hourly data so the forecast block is produced.
+  for (let h = 0; h < 24 * 31; h++) {
+    const t = Date.UTC(2025, 9, 1) + h * H;
+    prod.push({ start: t, end: t + H, kwh: 1 });
+    prices.push({ start: t, end: t + H, sekPerKwh: 1.0, eurPerKwh: 0 });
+  }
+  const withoutFees = analyze(prod, prices, { fuseAmps: 20, nextFuseMonthlyFee: 500, lowerFuseMonthlyFee: 300 });
+  eq(withoutFees.manads_prognos.har_fasta_avgifter, false, "no fees: flagged as missing");
+  eq(withoutFees.manads_prognos.snitt_netto_sek, undefined, "no fees: net omitted, not computed vs 0 kr");
+  eq(withoutFees.manads_prognos.fasta_avgifter_sek_per_man, undefined, "no fees: fee field omitted");
+  eq(withoutFees.manads_prognos.manader[0].netto_sek, undefined, "no fees: per-month net omitted");
+  eq(withoutFees.manads_prognos.snitt_production_kwh > 0, true, "no fees: production still reported");
+  eq(withoutFees.manads_prognos.snitt_effektiv_ersattning_sek > 0, true, "no fees: compensation still reported");
+  // The fuse verdicts compare against the current fee, so they need it.
+  eq(withoutFees.sakringsuppgradering, undefined, "no current fee: upgrade verdict omitted");
+  eq(withoutFees.sakringsnedgradering, undefined, "no current fee: downgrade verdict omitted");
+
+  const withFees = analyze(prod, prices, {
+    fuseAmps: 20,
+    gridMonthlyFee: 400,
+    nextFuseMonthlyFee: 500,
+    lowerFuseMonthlyFee: 300,
+  });
+  eq(withFees.manads_prognos.har_fasta_avgifter, true, "with fees: flagged present");
+  approx(withFees.manads_prognos.fasta_avgifter_sek_per_man, 400, "with fees: fee reported");
+  eq(typeof withFees.manads_prognos.snitt_netto_sek, "number", "with fees: net computed");
+  approx(withFees.sakringsuppgradering.extra_avgift_kr_per_man, 100, "with fees: upgrade delta 500-400");
+  approx(withFees.sakringsnedgradering.sparad_avgift_kr_per_man, 100, "with fees: downgrade saving 400-300");
+
+  // Only the trader fee given: still enough to report a net.
+  const traderOnly = analyze(prod, prices, { traderMonthlyFee: 59 });
+  eq(traderOnly.manads_prognos.har_fasta_avgifter, true, "trader fee only: net still reported");
+  approx(traderOnly.manads_prognos.fasta_avgifter_sek_per_man, 59, "trader fee only: fee = 59");
+  eq(traderOnly.manads_prognos.elnat_avgift_sek_per_man, undefined, "trader fee only: grid fee omitted");
+}
+
 console.log(failures === 0 ? "\nALL PASSED" : `\n${failures} FAILURE(S)`);
 process.exit(failures === 0 ? 0 : 1);

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -881,7 +881,9 @@ export default function Home() {
                       className="max-w-[12rem]"
                     />
                     <p className="text-xs text-muted-foreground">
-                      Fyll i för att se om det är värt att uppgradera huvudsäkringen ett steg (jämförs mot elnätets månadsavgift ovan).
+                      Fyll i för att se om det är värt att uppgradera huvudsäkringen ett steg. Kräver även{" "}
+                      <span className="text-foreground">elnätets nuvarande månadsavgift</span> nedan – jämförelsen görs
+                      mot den.
                     </p>
                   </div>
                 )}
@@ -902,7 +904,9 @@ export default function Home() {
                       className="max-w-[12rem]"
                     />
                     <p className="text-xs text-muted-foreground">
-                      Fyll i för att se om du kunde sänka säkringen ett steg – du sparar abonnemang men kapar exporttoppar över den lägre gränsen.
+                      Fyll i för att se om du kunde sänka säkringen ett steg – du sparar abonnemang men kapar exporttoppar
+                      över den lägre gränsen. Kräver även{" "}
+                      <span className="text-foreground">elnätets nuvarande månadsavgift</span> nedan.
                     </p>
                   </div>
                 )}
@@ -938,7 +942,9 @@ export default function Home() {
                 </div>
 
                 <div className="space-y-2">
-                  <h5 className="text-sm font-medium text-foreground">Fasta månadsavgifter</h5>
+                  <h5 className="text-sm font-medium text-foreground">
+                    Fasta månadsavgifter <span className="font-normal text-muted-foreground">(valfritt)</span>
+                  </h5>
                   <div className="grid grid-cols-2 gap-3">
                     <div className="space-y-2">
                       <Label htmlFor="grid-monthly" className="flex items-center gap-1.5">
@@ -956,7 +962,9 @@ export default function Home() {
                   <p className="text-xs text-muted-foreground">
                     Fasta abonnemangsavgifter – ange dem <span className="text-foreground">inkl. moms</span> (som på din
                     faktura). Till skillnad från öre-värdena dras de av rakt av från de uppskattade månadsintäkterna nedan.
-                    Elnätets avgift beror oftast på din säkringsstorlek ovan.
+                    Elnätets avgift beror oftast på din säkringsstorlek ovan. Lämnar du dem tomma får du fortfarande
+                    månadsrapporten – men bara ersättningen, inte nettot efter avgifter (en tom ruta betyder{" "}
+                    <span className="text-foreground">okänd avgift</span>, inte 0 kr).
                   </p>
                 </div>
 

--- a/frontend/src/components/analysis-results.tsx
+++ b/frontend/src/components/analysis-results.tsx
@@ -113,6 +113,8 @@ interface AnalysisData {
   manads_prognos?: {
     antal_manader?: number;
     fullstandiga_manader?: number;
+    /** False when no fixed monthly fee was entered — the net columns are then omitted. */
+    har_fasta_avgifter?: boolean;
     elnat_avgift_sek_per_man?: number;
     elhandel_avgift_sek_per_man?: number;
     fasta_avgifter_sek_per_man?: number;
@@ -985,8 +987,12 @@ export function AnalysisResults({
         </Card>
       )}
 
-      {/* Monthly forecast — what to expect per full-data month */}
-      {data.manads_prognos && (data.manads_prognos.fullstandiga_manader ?? 0) > 0 && (
+      {/* Monthly forecast — what to expect per full-data month. Without any fixed monthly fee
+          the net-after-fees figures are omitted rather than computed against 0 kr. */}
+      {data.manads_prognos && (data.manads_prognos.fullstandiga_manader ?? 0) > 0 && (() => {
+        const hasFixedFees =
+          data.manads_prognos.har_fasta_avgifter ?? data.manads_prognos.snitt_netto_sek != null;
+        return (
         <Card className="border-primary/20 bg-primary/5">
           <CardHeader className="pb-2">
             <div className="flex items-center gap-2">
@@ -996,23 +1002,41 @@ export function AnalysisResults({
             </div>
             <CardDescription>
               Per hel månad (delmånader är uppräknade till full månad) över {formatNumber(data.manads_prognos.antal_manader)} månader
-              {(data.manads_prognos.fasta_avgifter_sek_per_man ?? 0) > 0
+              {hasFixedFees
                 ? `, efter fasta avgifter (${formatCurrency(data.manads_prognos.fasta_avgifter_sek_per_man)}/mån)`
-                : ""}
+                : ", före fasta avgifter"}
             </CardDescription>
           </CardHeader>
           <CardContent>
-            <div className="flex items-baseline gap-2">
-              <span className={`text-3xl font-bold font-mono ${(data.manads_prognos.snitt_netto_sek ?? 0) < 0 ? "text-destructive" : "text-primary"}`}>
-                {formatCurrency(data.manads_prognos.snitt_netto_sek)}
-              </span>
-              <span className="text-muted-foreground">netto per månad i snitt</span>
-            </div>
-            <div className="mt-2 text-sm text-muted-foreground">
-              Ersättning {formatCurrency(data.manads_prognos.snitt_effektiv_ersattning_sek)}/mån − fasta avgifter{" "}
-              {formatCurrency(data.manads_prognos.fasta_avgifter_sek_per_man)}/mån. Snittproduktion{" "}
-              {formatNumber(data.manads_prognos.snitt_production_kwh, 0)} kWh/mån.
-            </div>
+            {hasFixedFees ? (
+              <>
+                <div className="flex items-baseline gap-2">
+                  <span className={`text-3xl font-bold font-mono ${(data.manads_prognos.snitt_netto_sek ?? 0) < 0 ? "text-destructive" : "text-primary"}`}>
+                    {formatCurrency(data.manads_prognos.snitt_netto_sek)}
+                  </span>
+                  <span className="text-muted-foreground">netto per månad i snitt</span>
+                </div>
+                <div className="mt-2 text-sm text-muted-foreground">
+                  Ersättning {formatCurrency(data.manads_prognos.snitt_effektiv_ersattning_sek)}/mån − fasta avgifter{" "}
+                  {formatCurrency(data.manads_prognos.fasta_avgifter_sek_per_man)}/mån. Snittproduktion{" "}
+                  {formatNumber(data.manads_prognos.snitt_production_kwh, 0)} kWh/mån.
+                </div>
+              </>
+            ) : (
+              <>
+                <div className="flex items-baseline gap-2">
+                  <span className="text-3xl font-bold font-mono text-primary">
+                    {formatCurrency(data.manads_prognos.snitt_effektiv_ersattning_sek)}
+                  </span>
+                  <span className="text-muted-foreground">ersättning per månad i snitt</span>
+                </div>
+                <div className="mt-2 text-sm text-muted-foreground">
+                  Snittproduktion {formatNumber(data.manads_prognos.snitt_production_kwh, 0)} kWh/mån. Fyll i{" "}
+                  <span className="text-foreground">fasta månadsavgifter</span> i inställningarna för att få netto efter
+                  avgifter.
+                </div>
+              </>
+            )}
 
             {data.manads_prognos.manader && data.manads_prognos.manader.length > 0 && (
               <div className="mt-4 overflow-x-auto">
@@ -1021,9 +1045,13 @@ export function AnalysisResults({
                     <tr className="border-b border-border/50 text-left text-muted-foreground">
                       <th className="py-2 pr-4 font-medium">Månad</th>
                       <th className="py-2 pr-4 font-medium text-right">Produktion</th>
-                      <th className="py-2 pr-4 font-medium text-right">Ersättning</th>
-                      <th className="py-2 pr-4 font-medium text-right">Fasta avgifter</th>
-                      <th className="py-2 font-medium text-right">Netto</th>
+                      <th className={`py-2 font-medium text-right${hasFixedFees ? " pr-4" : ""}`}>Ersättning</th>
+                      {hasFixedFees && (
+                        <>
+                          <th className="py-2 pr-4 font-medium text-right">Fasta avgifter</th>
+                          <th className="py-2 font-medium text-right">Netto</th>
+                        </>
+                      )}
                     </tr>
                   </thead>
                   <tbody className="font-mono">
@@ -1036,11 +1064,15 @@ export function AnalysisResults({
                           )}
                         </td>
                         <td className="py-1.5 pr-4 text-right">{formatNumber(m.production_kwh, 0)} kWh</td>
-                        <td className="py-1.5 pr-4 text-right">{formatCurrency(m.effektiv_ersattning_sek)}</td>
-                        <td className="py-1.5 pr-4 text-right text-muted-foreground">−{formatCurrency(m.fasta_avgifter_sek)}</td>
-                        <td className={`py-1.5 text-right ${(m.netto_sek ?? 0) < 0 ? "text-destructive" : "text-foreground"}`}>
-                          {formatCurrency(m.netto_sek)}
-                        </td>
+                        <td className={`py-1.5 text-right${hasFixedFees ? " pr-4" : ""}`}>{formatCurrency(m.effektiv_ersattning_sek)}</td>
+                        {hasFixedFees && (
+                          <>
+                            <td className="py-1.5 pr-4 text-right text-muted-foreground">−{formatCurrency(m.fasta_avgifter_sek)}</td>
+                            <td className={`py-1.5 text-right ${(m.netto_sek ?? 0) < 0 ? "text-destructive" : "text-foreground"}`}>
+                              {formatCurrency(m.netto_sek)}
+                            </td>
+                          </>
+                        )}
                       </tr>
                     ))}
                   </tbody>
@@ -1049,7 +1081,8 @@ export function AnalysisResults({
             )}
           </CardContent>
         </Card>
-      )}
+        );
+      })()}
 
       {/* Self-consumption valuation (separate, optional) — per-month savings breakdown */}
       {data.sjalvkonsumtion && (

--- a/frontend/src/lib/analyze.ts
+++ b/frontend/src/lib/analyze.ts
@@ -405,8 +405,13 @@ export function analyze(
   // value it at the effective export price during the very quarters that hit the cap.
   const upgFuseAmps = opts.fuseAmps ?? 0;
   const upgVoltage = opts.voltage ?? 400;
+  // Both fuse verdicts compare the *current* subscription fee against the alternative one,
+  // so they need both numbers. Without the current fee the comparison would be against
+  // 0 kr/month, which reads as a confident answer while being meaningless — omit instead.
   const upgNextAmps =
-    upgFuseAmps > 0 && opts.nextFuseMonthlyFee != null ? nextFuseStep(upgFuseAmps) : undefined;
+    upgFuseAmps > 0 && opts.nextFuseMonthlyFee != null && opts.gridMonthlyFee != null
+      ? nextFuseStep(upgFuseAmps)
+      : undefined;
   const upgCurLimitKw = (SQRT3 * upgVoltage * upgFuseAmps) / 1000;
   const upgNextLimitKw = upgNextAmps ? (SQRT3 * upgVoltage * upgNextAmps) / 1000 : 0;
   const upgThreshold = upgCurLimitKw * MAXED_FRACTION;
@@ -438,7 +443,9 @@ export function analyze(
   // concrete: from your actual production we know exactly how much export would be clipped if
   // the fuse were lowered (the part of each quarter's power above the lower limit).
   const dnPrevAmps =
-    upgFuseAmps > 0 && opts.lowerFuseMonthlyFee != null ? prevFuseStep(upgFuseAmps) : undefined;
+    upgFuseAmps > 0 && opts.lowerFuseMonthlyFee != null && opts.gridMonthlyFee != null
+      ? prevFuseStep(upgFuseAmps)
+      : undefined;
   const dnPrevLimitKw = dnPrevAmps ? (SQRT3 * upgVoltage * dnPrevAmps) / 1000 : 0;
   let dnLostKwh = 0;
   let dnLostValue = 0;
@@ -591,8 +598,12 @@ export function analyze(
   // Monthly forecast: for each month with FULL data coverage, project what to expect.
   // Effective compensation aggregates affinely from the month's spot revenue and energy;
   // net subtracts the fixed monthly fees (elnät subscription + elhandel monthly fee).
+  // Fixed monthly fees are optional. When none is given we still report production and
+  // effective compensation per month, but omit the net-after-fees figures rather than
+  // silently treating an unfilled fee as 0 kr — that would overstate the net.
   const gridMonthlyFee = opts.gridMonthlyFee ?? 0;
   const traderMonthlyFee = opts.traderMonthlyFee ?? 0;
+  const hasFixedMonthly = opts.gridMonthlyFee != null || opts.traderMonthlyFee != null;
   const fixedMonthly = gridMonthlyFee + traderMonthlyFee;
   const DAY_MS = 24 * MS_PER_HOUR;
   // Always express the forecast per FULL month so the fixed monthly fees apply consistently.
@@ -624,9 +635,10 @@ export function analyze(
       ? {
           antal_manader: forecastMonths.length,
           fullstandiga_manader: forecastMonths.filter((m) => m.complete).length,
-          elnat_avgift_sek_per_man: round(gridMonthlyFee, 2),
-          elhandel_avgift_sek_per_man: round(traderMonthlyFee, 2),
-          fasta_avgifter_sek_per_man: round(fixedMonthly, 2),
+          har_fasta_avgifter: hasFixedMonthly,
+          elnat_avgift_sek_per_man: opts.gridMonthlyFee != null ? round(gridMonthlyFee, 2) : undefined,
+          elhandel_avgift_sek_per_man: opts.traderMonthlyFee != null ? round(traderMonthlyFee, 2) : undefined,
+          fasta_avgifter_sek_per_man: hasFixedMonthly ? round(fixedMonthly, 2) : undefined,
           manader: forecastMonths.map((m) => ({
             period: m.period,
             complete: m.complete,
@@ -634,12 +646,14 @@ export function analyze(
             dagar_i_manad: Math.round(m.daysInMonth),
             production_kwh: round(m.production, 1),
             effektiv_ersattning_sek: round(m.effective, 2),
-            fasta_avgifter_sek: round(fixedMonthly, 2),
-            netto_sek: round(m.net, 2),
+            fasta_avgifter_sek: hasFixedMonthly ? round(fixedMonthly, 2) : undefined,
+            netto_sek: hasFixedMonthly ? round(m.net, 2) : undefined,
           })),
           snitt_production_kwh: round(forecastMonths.reduce((s, m) => s + m.production, 0) / forecastMonths.length, 1),
           snitt_effektiv_ersattning_sek: round(forecastMonths.reduce((s, m) => s + m.effective, 0) / forecastMonths.length, 2),
-          snitt_netto_sek: round(forecastMonths.reduce((s, m) => s + m.net, 0) / forecastMonths.length, 2),
+          snitt_netto_sek: hasFixedMonthly
+            ? round(forecastMonths.reduce((s, m) => s + m.net, 0) / forecastMonths.length, 2)
+            : undefined,
         }
       : undefined;
 

--- a/frontend/src/lib/parseProduction.ts
+++ b/frontend/src/lib/parseProduction.ts
@@ -7,9 +7,15 @@ import type { Granularity, ParsedProduction, ProductionInterval } from "./types"
 import { readWorkbook, type WorkbookSheet } from "./xlsx.ts";
 
 const DATE_HINTS = /(datum|date|tid|time|timestamp|från|start|period|hour|timme)/i;
+/** Columns holding the interval's *end* timestamp (E.ON "Sluttidpunkt"). Kept narrow so
+ *  ordinary words that merely contain "end" (e.g. "Kalender") don't match. */
+const END_HINTS = /(^slut|sluttid|slutdatum|^end\b|end_?(time|date)|^till$|t\.o\.m)/i;
 const PROD_HINTS =
-  /(produktion|production|export|inmatning|inmatad|levererad|kwh|mwh|energi|förbrukning|consumption|effekt|power|värde|value|netto)/i;
-const PREFERRED_PROD = /(export|inmat|produktion|production|kwh)/i;
+  /(produktion|production|export|inmatning|inmatad|levererad|kwh|mwh|energi|förbrukning|consumption|effekt|power|värde|value|netto|kvantitet|quantity|mängd)/i;
+const PREFERRED_PROD = /(export|inmat|produktion|production|kwh|kvantitet|quantity)/i;
+/** Column that says whether a row is production or consumption (E.ON "Energiriktning"). */
+const DIRECTION_HINTS = /(riktning|direction)/i;
+const PRODUCTION_DIRECTION = /(produktion|production|export|inmatning|inmatad|utmatad|levererad)/i;
 
 /** Parse a Swedish/European or plain number string into a float, or NaN. */
 export function parseNumber(raw: string): number {
@@ -120,6 +126,57 @@ function granularityFromMinutes(step: number): Granularity {
   return "daily";
 }
 
+/**
+ * Find the row that actually heads the data table.
+ *
+ * Most exports put the header on line 1, but E.ON's "Mätvärdesexport" (and a few other
+ * Swedish meter exports) prepend a metadata block — plant id, export timestamp, unit —
+ * with its own header/value pair, then a blank line, then the real table. Naively taking
+ * line 1 makes every data row unparseable.
+ *
+ * Scores each candidate by how many rows immediately below it share its column count and
+ * look like data (a parseable timestamp plus a parseable number). The real header is
+ * followed by thousands of such rows; a metadata header is followed by one. Ties go to the
+ * earliest row, so ordinary single-header files behave exactly as before.
+ */
+function findHeaderRow(lines: string[]): { index: number; delim: string } {
+  const MAX_PREAMBLE = 25; // metadata blocks are a handful of lines, never deep
+  const MAX_PROBE = 40; // enough to separate "real table" from "one metadata row"
+  let best = { index: 0, delim: detectDelimiter(lines[0]), score: -1 };
+
+  for (let h = 0; h < Math.min(lines.length - 1, MAX_PREAMBLE); h++) {
+    const delim = detectDelimiter(lines[h]);
+    const width = splitLine(lines[h], delim).length;
+    if (width < 2) continue;
+    let score = 0;
+    for (let r = h + 1; r < lines.length && score < MAX_PROBE; r++) {
+      const row = splitLine(lines[r], delim);
+      if (row.length !== width) break;
+      const hasTs = row.some((c) => parseTimestamp(c) != null);
+      const hasNum = row.some((c) => Number.isFinite(parseNumber(c)));
+      if (!hasTs || !hasNum) break;
+      score++;
+    }
+    if (score > best.score) best = { index: h, delim, score };
+  }
+  return best;
+}
+
+/**
+ * Unit of the value column. E.ON states it in the metadata block ("Måttenhet;kWh") rather
+ * than in the value column's own header, so fall back to scanning the skipped preamble.
+ */
+function detectMwh(valueHeader: string, preamble: string[][]): boolean {
+  if (/mwh/i.test(valueHeader)) return !/kwh/i.test(valueHeader);
+  for (const row of preamble) {
+    for (const cell of row) {
+      if (/^mwh$/i.test(cell.trim())) return true;
+      if (/^kwh$/i.test(cell.trim())) return false;
+    }
+  }
+  return false;
+}
+
 export function parseProductionCsv(text: string, filename = ""): ParsedProduction {
   if (/\.xls[xm]?$/i.test(filename) && /PK/.test(text.slice(0, 4))) {
     // Excel files are binary (a ZIP); route them through parseProductionXlsx, not here.
@@ -131,63 +188,99 @@ export function parseProductionCsv(text: string, filename = ""): ParsedProductio
   const rawLines = text.split(/\r?\n/).filter((l) => l.trim() !== "");
   if (rawLines.length < 2) throw new Error("Filen verkar tom eller saknar datarader.");
 
-  const delim = detectDelimiter(rawLines[0]);
-  const header = splitLine(rawLines[0], delim);
+  // Skip any metadata preamble (E.ON) and use the row that really heads the table.
+  const { index: headerIdx, delim } = findHeaderRow(rawLines);
+  const header = splitLine(rawLines[headerIdx], delim);
+  const preamble = rawLines.slice(0, headerIdx).map((l) => splitLine(l, delim));
+  const firstDataRow = headerIdx + 1 < rawLines.length ? splitLine(rawLines[headerIdx + 1], delim) : [];
 
   // Locate columns by header hints.
   let dtIdx = header.findIndex((h) => DATE_HINTS.test(h));
+  if (dtIdx === -1) dtIdx = 0;
+
+  // An explicit interval-end column ("Sluttidpunkt") is authoritative — but only if it
+  // really holds timestamps, so a look-alike header can't hijack the value column.
+  const endIdx = header.findIndex(
+    (h, i) =>
+      i !== dtIdx && END_HINTS.test(h) && parseTimestamp(firstDataRow[i] ?? "") != null
+  );
+
+  // Rows may be tagged production vs consumption; we only want what was fed to the grid.
+  const dirIdx = header.findIndex((h, i) => i !== dtIdx && i !== endIdx && DIRECTION_HINTS.test(h));
+
+  const skip = (i: number) => i === dtIdx || i === endIdx || i === dirIdx;
+
   let prodIdx = -1;
   // Prefer columns whose header clearly means exported energy.
   for (let i = 0; i < header.length; i++) {
-    if (i === dtIdx) continue;
+    if (skip(i)) continue;
     if (PREFERRED_PROD.test(header[i])) {
       prodIdx = i;
       break;
     }
   }
-  if (prodIdx === -1) prodIdx = header.findIndex((h, i) => i !== dtIdx && PROD_HINTS.test(h));
+  if (prodIdx === -1) prodIdx = header.findIndex((h, i) => !skip(i) && PROD_HINTS.test(h));
 
-  // Fallback: first column is datetime, first numeric column is production.
-  if (dtIdx === -1) dtIdx = 0;
+  // Fallback: first numeric column that isn't a timestamp/direction column.
   if (prodIdx === -1) {
-    const probe = splitLine(rawLines[1], delim);
-    prodIdx = probe.findIndex((v, i) => i !== dtIdx && Number.isFinite(parseNumber(v)));
+    prodIdx = firstDataRow.findIndex(
+      (v, i) => !skip(i) && Number.isFinite(parseNumber(v)) && parseTimestamp(v) == null
+    );
   }
   if (prodIdx === -1) throw new Error("Hittade ingen produktions-/exportkolumn i filen.");
 
-  const isMwh = /mwh/i.test(header[prodIdx]) && !/kwh/i.test(header[prodIdx]);
+  const isMwh = detectMwh(header[prodIdx], preamble);
 
   // Parse rows.
-  const points: { start: number; kwh: number }[] = [];
-  for (let r = 1; r < rawLines.length; r++) {
+  const points: { start: number; end: number | null; kwh: number }[] = [];
+  const widest = Math.max(dtIdx, prodIdx, endIdx, dirIdx);
+  for (let r = headerIdx + 1; r < rawLines.length; r++) {
     const cols = splitLine(rawLines[r], delim);
-    if (cols.length <= Math.max(dtIdx, prodIdx)) continue;
+    if (cols.length <= widest) continue;
+    // Consumption/import row in a mixed export — not our series.
+    if (dirIdx >= 0 && cols[dirIdx] && !PRODUCTION_DIRECTION.test(cols[dirIdx])) continue;
     const ts = parseTimestamp(cols[dtIdx]);
     const val = parseNumber(cols[prodIdx]);
     if (ts == null || !Number.isFinite(val)) continue;
-    points.push({ start: ts, kwh: isMwh ? val * 1000 : val });
+    const end = endIdx >= 0 ? parseTimestamp(cols[endIdx]) : null;
+    points.push({ start: ts, end: end != null && end > ts ? end : null, kwh: isMwh ? val * 1000 : val });
   }
 
   if (points.length === 0) throw new Error("Kunde inte tolka några giltiga rader (datum + värde).");
   points.sort((a, b) => a.start - b.start);
 
-  // Infer the interval length from spacing between consecutive timestamps.
+  // Interval length: prefer each row's own declared duration (E.ON ships start+end), and
+  // fall back to the spacing between consecutive start timestamps. Declared durations stay
+  // correct across gaps in the series, where start-to-start spacing does not.
+  const declaredMin = points.filter((p) => p.end != null).map((p) => (p.end! - p.start) / 60000);
   const diffsMin: number[] = [];
   for (let i = 1; i < points.length; i++) {
     const d = (points[i].start - points[i - 1].start) / 60000;
     if (d > 0) diffsMin.push(d);
   }
-  const stepMinutes = diffsMin.length ? median(diffsMin) : 60;
+  // Only trust declared durations when most rows carry one.
+  const useDeclared = declaredMin.length >= points.length * 0.9 && declaredMin.length > 0;
+  const sample = useDeclared ? declaredMin : diffsMin;
+  const stepMinutes = sample.length ? median(sample) : 60;
   const stepMs = stepMinutes * 60000;
 
-  // How regular is the spacing? (share of gaps equal to the dominant step, within 10%).
+  // How regular is the data? (share of intervals equal to the dominant step, within 10%).
   const tol = Math.max(1, stepMinutes * 0.1);
-  const matching = diffsMin.filter((d) => Math.abs(d - stepMinutes) <= tol).length;
-  const stepConsistencyPct = diffsMin.length
-    ? Math.round((matching / diffsMin.length) * 1000) / 10
+  const matching = sample.filter((d) => Math.abs(d - stepMinutes) <= tol).length;
+  const stepConsistencyPct = sample.length
+    ? Math.round((matching / sample.length) * 1000) / 10
     : 100;
 
   const rows: ProductionInterval[] = points.map((p, i) => {
+    if (p.end != null) {
+      // A declared span far longer than the step is a clock artifact rather than a real
+      // duration: at the spring-forward DST switch E.ON writes "01:45 -> 03:00" for a
+      // single quarter, because the wall clock jumps an hour. Timestamps here are naive
+      // wall-clock, so charging that row 75 minutes would give it five times its true
+      // weight in the duration-based metrics. Cap it at the normal step.
+      const end = p.end - p.start > 2 * stepMs ? p.start + stepMs : p.end;
+      return { start: p.start, end, kwh: p.kwh };
+    }
     const next = i + 1 < points.length ? points[i + 1].start : p.start + stepMs;
     // Guard against gaps: cap an interval at the inferred step length.
     const end = Math.min(next, p.start + stepMs);

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -137,9 +137,15 @@ export interface AnalysisResult {
   manads_prognos?: {
     antal_manader: number;
     fullstandiga_manader: number;
-    elnat_avgift_sek_per_man: number;
-    elhandel_avgift_sek_per_man: number;
-    fasta_avgifter_sek_per_man: number;
+    /**
+     * True when at least one fixed monthly fee was supplied. When false the net-after-fees
+     * fields below are omitted (an unfilled fee is "unknown", not 0 kr), and the forecast
+     * reports production and effective compensation only.
+     */
+    har_fasta_avgifter: boolean;
+    elnat_avgift_sek_per_man?: number;
+    elhandel_avgift_sek_per_man?: number;
+    fasta_avgifter_sek_per_man?: number;
     manader: Array<{
       period: string;
       /** True if the month had full data; false if scaled up from a partial month. */
@@ -148,12 +154,12 @@ export interface AnalysisResult {
       dagar_i_manad: number;
       production_kwh: number;
       effektiv_ersattning_sek: number;
-      fasta_avgifter_sek: number;
-      netto_sek: number;
+      fasta_avgifter_sek?: number;
+      netto_sek?: number;
     }>;
     snitt_production_kwh: number;
     snitt_effektiv_ersattning_sek: number;
-    snitt_netto_sek: number;
+    snitt_netto_sek?: number;
   };
   /**
    * Effective export compensation: what you actually get paid for exported energy.

--- a/python/core/intervals.py
+++ b/python/core/intervals.py
@@ -6,6 +6,7 @@ one hour". These helpers infer the per-row interval length so energy/cost sums a
 "hours" metrics stay correct at any resolution.
 """
 
+import re
 from dataclasses import dataclass
 from typing import List, Tuple
 
@@ -175,3 +176,30 @@ def assess_resolution(index: pd.DatetimeIndex) -> ResolutionAssessment:
             "quarters and short export peaks."
         ),
     )
+
+
+# Column naming each row's energy direction, and the values meaning "fed to the grid".
+DIRECTION_HINTS = re.compile(r"(?:riktning|direction)", re.I)
+# Non-capturing: pandas' str.contains warns when a pattern has match groups.
+PRODUCTION_DIRECTION = re.compile(
+    r"(?:produktion|production|export|inmatning|inmatad|utmatad|levererad)", re.I
+)
+
+
+def filter_production_direction(df: pd.DataFrame) -> pd.DataFrame:
+    """Keep only production rows when the export tags each row's energy direction.
+
+    E.ON's "Mätvärdesexport" carries an "Energiriktning" column; a file holding both
+    Produktion and Förbrukning would otherwise sum consumption into production. This is a
+    no-op when there is no such column, or when every row already has the same direction.
+
+    Mirrors the Energiriktning filter in frontend/src/lib/parseProduction.ts.
+    """
+    for c in df.columns:
+        if not DIRECTION_HINTS.search(str(c)):
+            continue
+        is_production = df[c].astype(str).str.contains(PRODUCTION_DIRECTION)
+        if is_production.any() and not is_production.all():
+            return df[is_production].copy()
+        return df
+    return df

--- a/python/core/price_analyzer.py
+++ b/python/core/price_analyzer.py
@@ -479,8 +479,12 @@ class PriceAnalyzer:
         # consistently. Partial months (start/end of the data) are scaled up by their
         # coverage and flagged. Mirrors analyze.ts.
         if total_kwh > 0:
+            # Fixed monthly fees are optional. Without any, report production and effective
+            # compensation but omit the net-after-fees figures rather than silently treating
+            # an unfilled fee as 0 kr (which would overstate the net). Mirrors analyze.ts.
             g_month = grid_monthly_fee or 0.0
             t_month = trader_monthly_fee or 0.0
+            has_fixed_monthly = grid_monthly_fee is not None or trader_monthly_fee is not None
             fixed_monthly = g_month + t_month
             pct_frac = (g_pct + t_pct) / 100.0
             tot_fixed = g_fixed + t_fixed
@@ -507,21 +511,26 @@ class PriceAnalyzer:
                     'days_in_month': round(days_in_month),
                     'production_kwh': round(kwh_month * scale, 1),
                     'effective_sek': round(effective * scale, 2),
-                    'fixed_fees_sek': round(fixed_monthly, 2),
-                    'net_sek': round(effective * scale - fixed_monthly, 2),
+                    'fixed_fees_sek': round(fixed_monthly, 2) if has_fixed_monthly else None,
+                    'net_sek': round(effective * scale - fixed_monthly, 2) if has_fixed_monthly else None,
                 })
             if forecast_months:
                 n = len(forecast_months)
                 analysis['monthly_forecast'] = {
                     'months_count': n,
                     'full_months': sum(1 for m in forecast_months if m['complete']),
-                    'grid_monthly_fee_sek': round(g_month, 2),
-                    'trader_monthly_fee_sek': round(t_month, 2),
-                    'fixed_monthly_sek': round(fixed_monthly, 2),
+                    'has_fixed_fees': has_fixed_monthly,
+                    'grid_monthly_fee_sek': round(g_month, 2) if grid_monthly_fee is not None else None,
+                    'trader_monthly_fee_sek': round(t_month, 2) if trader_monthly_fee is not None else None,
+                    'fixed_monthly_sek': round(fixed_monthly, 2) if has_fixed_monthly else None,
                     'months': forecast_months,
                     'avg_production_kwh': round(sum(m['production_kwh'] for m in forecast_months) / n, 1),
                     'avg_effective_sek': round(sum(m['effective_sek'] for m in forecast_months) / n, 2),
-                    'avg_net_sek': round(sum(m['net_sek'] for m in forecast_months) / n, 2),
+                    'avg_net_sek': (
+                        round(sum(m['net_sek'] for m in forecast_months) / n, 2)
+                        if has_fixed_monthly
+                        else None
+                    ),
                 }
 
         # Fuse upgrade ("is a bigger main fuse worth it?"). Mirrors analyze.ts
@@ -529,7 +538,14 @@ class PriceAnalyzer:
         # (best-case) value of export a bigger fuse would unlock during the quarters that hit
         # the cap — counting only sustained clipping (≥2 consecutive intervals) and bounded by
         # the installed kWp (a bigger fuse only helps up to what the panels can produce).
-        next_amp = next_fuse_step(fuse_amps) if (fuse_amps and next_fuse_monthly_fee is not None) else None
+        # Both fuse verdicts compare the *current* subscription fee against the alternative,
+        # so they need both numbers; without the current fee the comparison would run against
+        # 0 kr/month and read as a confident answer while being meaningless. Mirrors analyze.ts.
+        next_amp = (
+            next_fuse_step(fuse_amps)
+            if (fuse_amps and next_fuse_monthly_fee is not None and grid_monthly_fee is not None)
+            else None
+        )
         if next_amp is not None:
             cur_limit_kw = (3 ** 0.5) * voltage * fuse_amps / 1000.0
             next_limit_kw = (3 ** 0.5) * voltage * next_amp / 1000.0
@@ -601,7 +617,11 @@ class PriceAnalyzer:
         # Fuse downgrade ("would a smaller fuse pay off?"). Mirrors analyze.ts
         # sakringsnedgradering: weigh the annual subscription saving against the export a lower
         # fuse would clip (power above the lower limit). Concrete, from the actual production.
-        prev_amp = prev_fuse_step(fuse_amps) if (fuse_amps and lower_fuse_monthly_fee is not None) else None
+        prev_amp = (
+            prev_fuse_step(fuse_amps)
+            if (fuse_amps and lower_fuse_monthly_fee is not None and grid_monthly_fee is not None)
+            else None
+        )
         if prev_amp is not None:
             cur_limit_kw = (3 ** 0.5) * voltage * fuse_amps / 1000.0
             prev_limit_kw = (3 ** 0.5) * voltage * prev_amp / 1000.0

--- a/python/core/production_loader.py
+++ b/python/core/production_loader.py
@@ -4,6 +4,7 @@ from typing import Optional, Tuple
 import numpy as np
 import pandas as pd
 
+from core.intervals import filter_production_direction
 from utils.csv_format_detector_fallback import CSVFormatDetectorFallback
 from utils.ai_table_reader import AITableReader
 
@@ -87,6 +88,7 @@ class ProductionLoader:
     ) -> Tuple[pd.DataFrame, str]:
         """Process DataFrame when column names are known (from AI)."""
         df = df.rename(columns={c: str(c).strip() for c in df.columns})
+        df = filter_production_direction(df)
 
         # Validate columns exist
         if datetime_col not in df.columns:
@@ -125,6 +127,7 @@ class ProductionLoader:
     def _process_auto(self, df: pd.DataFrame) -> Tuple[pd.DataFrame, str]:
         """Process DataFrame with auto-detected columns (fallback path)."""
         df = df.rename(columns={c: str(c).strip() for c in df.columns})
+        df = filter_production_direction(df)
 
         date_col = self._infer_date_col(df)
         prod_col = self._infer_prod_col(df)

--- a/python/test_intervals.py
+++ b/python/test_intervals.py
@@ -9,8 +9,9 @@ import pandas as pd
 import pytest
 
 from core.intervals import (assess_resolution, combine_production,
-                            granularity_from_hours, infer_step_hours,
-                            interval_hours_series, step_consistency_pct)
+                            filter_production_direction, granularity_from_hours,
+                            infer_step_hours, interval_hours_series,
+                            step_consistency_pct)
 from core.price_analyzer import PriceAnalyzer, next_fuse_step, prev_fuse_step
 
 
@@ -424,3 +425,110 @@ def test_db_has_data_for_period_is_resolution_aware(tmp_path):
     # 96 quarter-hour points cover the day; the hourly-only heuristic would also pass,
     # but this confirms 15-min density is accepted as complete.
     assert db.has_data_for_period("SE3", start, end) is True
+
+
+# --- E.ON "Mätvärdesexport" format + optional fixed monthly fees -------------------
+
+
+EON_CSV = """\ufeffAnläggnings-id;Tidpunkt för export;Energiprodukt;Starttidpunkt;Sluttidpunkt;Måttenhet
+735999114013307011;2026-07-30 12:57:06;Aktiv energi;2025-10-01 00:00:00;2025-10-01 01:00:00;kWh
+
+Starttidpunkt;Sluttidpunkt;Energiriktning;Kvalitet;Kvantitet
+2025-10-01 00:00:00;2025-10-01 00:15:00;Produktion;Uppmätt;0,100
+2025-10-01 00:15:00;2025-10-01 00:30:00;Produktion;Uppmätt;0,200
+2025-10-01 00:30:00;2025-10-01 00:45:00;Produktion;Uppmätt;0,300
+2025-10-01 00:45:00;2025-10-01 01:00:00;Produktion;Uppmätt;0,400
+"""
+
+
+def test_eon_export_skips_metadata_preamble(tmp_path):
+    """E.ON prefixes the table with a metadata block; the real header is further down."""
+    from utils.csv_format_detector_fallback import CSVFormatDetectorFallback
+
+    path = tmp_path / "Mätvärdesexport.CSV"
+    path.write_text(EON_CSV, encoding="utf-8")
+
+    df = CSVFormatDetectorFallback().read(str(path))
+    assert list(df.columns) == [
+        "Starttidpunkt",
+        "Sluttidpunkt",
+        "Energiriktning",
+        "Kvalitet",
+        "Kvantitet",
+    ]
+    assert len(df) == 4
+    assert df["Kvantitet"].sum() == pytest.approx(1.0)
+
+
+def test_ordinary_csv_header_row_unaffected(tmp_path):
+    """A normal single-header file must still be read from line 1."""
+    from utils.csv_format_detector_fallback import CSVFormatDetectorFallback
+
+    path = tmp_path / "plain.csv"
+    path.write_text(
+        "Datum;Produktion kWh\n2025-10-01 00:00;1,5\n2025-10-01 01:00;2,5\n", encoding="utf-8"
+    )
+    df = CSVFormatDetectorFallback().read(str(path))
+    assert list(df.columns) == ["Datum", "Produktion kWh"]
+    assert len(df) == 2
+
+
+def test_energiriktning_filters_out_consumption_rows():
+    """A mixed export must not sum Förbrukning into production."""
+    df = pd.DataFrame(
+        {
+            "Starttidpunkt": ["2025-10-01 00:00", "2025-10-01 00:00", "2025-10-01 00:15"],
+            "Energiriktning": ["Produktion", "Förbrukning", "Produktion"],
+            "Kvantitet": [1.0, 9.0, 2.0],
+        }
+    )
+    out = filter_production_direction(df)
+    assert len(out) == 2
+    assert out["Kvantitet"].sum() == pytest.approx(3.0)
+
+    # No direction column -> untouched.
+    plain = pd.DataFrame({"Datum": ["2025-10-01 00:00"], "kWh": [1.0]})
+    assert len(filter_production_direction(plain)) == 1
+
+
+def _one_month_merged():
+    idx = pd.date_range("2025-10-01 00:00", periods=24 * 31, freq="h")
+    prices = pd.DataFrame({"price_eur_per_mwh": [100.0] * len(idx)}, index=idx)
+    production = pd.DataFrame({"production_kwh": [1.0] * len(idx)}, index=idx)
+    return PriceAnalyzer.merge_data(prices, production, eur_sek_rate=10.0)
+
+
+def test_monthly_forecast_omits_net_without_fixed_fees():
+    """An unfilled monthly fee means 'unknown', not 0 kr — so no net is reported."""
+    merged = _one_month_merged()
+    a = PriceAnalyzer.analyze_data(merged, fuse_amps=20, next_fuse_monthly_fee=500,
+                                   lower_fuse_monthly_fee=300)
+    f = a["monthly_forecast"]
+    assert f["has_fixed_fees"] is False
+    assert f["avg_net_sek"] is None
+    assert f["fixed_monthly_sek"] is None
+    assert f["months"][0]["net_sek"] is None
+    # Production and compensation are still known, so they are still reported.
+    assert f["avg_production_kwh"] > 0
+    assert f["avg_effective_sek"] > 0
+    # Both fuse verdicts compare against the current fee, so they need it.
+    assert "fuse_upgrade" not in a
+    assert "fuse_downgrade" not in a
+
+
+def test_monthly_forecast_reports_net_with_fixed_fees():
+    merged = _one_month_merged()
+    a = PriceAnalyzer.analyze_data(merged, fuse_amps=20, grid_monthly_fee=400,
+                                   next_fuse_monthly_fee=500, lower_fuse_monthly_fee=300)
+    f = a["monthly_forecast"]
+    assert f["has_fixed_fees"] is True
+    assert f["fixed_monthly_sek"] == pytest.approx(400)
+    assert f["avg_net_sek"] is not None
+    assert a["fuse_upgrade"]["extra_fee_sek_per_month"] == pytest.approx(100)
+    assert a["fuse_downgrade"]["saved_fee_sek_per_month"] == pytest.approx(100)
+
+    # Trader fee alone is enough to report a net.
+    only_trader = PriceAnalyzer.analyze_data(merged, trader_monthly_fee=59)["monthly_forecast"]
+    assert only_trader["has_fixed_fees"] is True
+    assert only_trader["fixed_monthly_sek"] == pytest.approx(59)
+    assert only_trader["grid_monthly_fee_sek"] is None

--- a/python/utils/csv_format_detector_fallback.py
+++ b/python/utils/csv_format_detector_fallback.py
@@ -1,5 +1,6 @@
 import pandas as pd
 import csv
+import re
 import chardet
 import logging
 
@@ -17,24 +18,94 @@ class CSVFormatDetectorFallback:
         """Detect CSV format using traditional methods."""
         encoding = self._detect_encoding(file_path)
         separator = self._detect_separator(file_path, encoding)
+        sep = separator or ';'
 
         test_params = {
-            'sep': separator or ';',
+            'sep': sep,
             'encoding': (encoding or 'utf-8-sig'),
             'na_values': ['', 'NA', 'N/A', 'null', 'NULL', 'None', '-'],
             'thousands': None,
-            'decimal': ',' if separator == ';' else '.',
+            'decimal': ',' if sep == ';' else '.',
             'skipinitialspace': True,
             'quotechar': '"',
         }
 
+        header_row = self._detect_header_row(file_path, test_params['encoding'], sep)
+        if header_row > 0:
+            logger.info(f"Skipping {header_row} metadata line(s) above the data header")
+            test_params['skiprows'] = header_row
+
         try:
-            df_test = pd.read_csv(file_path, nrows=5, **test_params)
+            pd.read_csv(file_path, nrows=5, **test_params)
             logger.info(f"Detected format: {test_params}")
             return test_params
         except Exception as e:
             logger.error(f"Format detection failed: {e}")
             raise
+
+    def _detect_header_row(self, file_path, encoding, separator, max_preamble=25, max_probe=40):
+        """Find the line that actually heads the data table.
+
+        E.ON's "Mätvärdesexport" prefixes the table with a metadata block (plant id, export
+        timestamp, unit) that has its own header/value pair, a blank line, and a different
+        column count -- so reading from line 1 mis-parses or raises. Score each candidate by
+        how many following lines share its column count and look like data; the real header
+        is followed by thousands of them, a metadata header by one. Ties go to the earliest
+        line, so ordinary single-header files are unaffected (returns 0).
+
+        Mirrors findHeaderRow() in frontend/src/lib/parseProduction.ts.
+        """
+        try:
+            with open(file_path, 'r', encoding=encoding, errors='replace') as f:
+                lines = [ln for ln in (f.readline() for _ in range(max_preamble + max_probe + 2)) if ln]
+        except Exception as e:
+            logger.warning(f"Header-row detection failed: {e}")
+            return 0
+
+        rows = [ln.rstrip('\r\n').split(separator) for ln in lines if ln.strip() != '']
+        if len(rows) < 2:
+            return 0
+
+        def looks_like_data(cells):
+            has_ts = any(self._is_timestamp(c) for c in cells)
+            has_num = any(self._is_number(c) for c in cells)
+            return has_ts and has_num
+
+        best_index, best_score = 0, -1
+        for h in range(min(len(rows) - 1, max_preamble)):
+            width = len(rows[h])
+            if width < 2:
+                continue
+            score = 0
+            for r in range(h + 1, len(rows)):
+                if score >= max_probe:
+                    break
+                if len(rows[r]) != width or not looks_like_data(rows[r]):
+                    break
+                score += 1
+            if score > best_score:
+                best_index, best_score = h, score
+        return best_index
+
+    # Date shapes accepted by the header probe: ISO (optionally with a time) and European
+    # D.M.YYYY / D/M/YYYY. A regex keeps the probe fast over many lines and avoids pandas'
+    # dayfirst parsing warnings; exact parsing happens later, on the real columns.
+    _TIMESTAMP_RE = re.compile(
+        r"^\s*(?:\d{4}[-/]\d{1,2}[-/]\d{1,2}|\d{1,2}[./]\d{1,2}[./]\d{4})"
+        r"(?:[T ]\d{1,2}:\d{2}(?::\d{2})?)?\s*$"
+    )
+
+    @classmethod
+    def _is_timestamp(cls, cell):
+        return bool(cls._TIMESTAMP_RE.match(cell))
+
+    @staticmethod
+    def _is_number(cell):
+        try:
+            float(cell.strip().replace(' ', '').replace(',', '.'))
+            return True
+        except (ValueError, AttributeError):
+            return False
 
     def read(self, file_path):
         """Read CSV with detected format parameters."""


### PR DESCRIPTION
## Vad det här löser

Johan skickade in en fil från E.ON – en `Mätvärdesexport` – och appen kunde inte läsa den alls. Den föll direkt på **"Kunde inte tolka några giltiga rader (datum + värde)"**.

Orsaken: E.ON lägger ett metadatablock överst i filen (anläggnings-id, exporttidpunkt, måttenhet) med *egen* rubrikrad och ett annat antal kolumner. Parsern tog rad 1 som tabellrubrik, landade på "Tidpunkt för export" som datumkolumn och "Energiprodukt" som värdekolumn – och kastade därmed varenda datarad.

Efter den här ändringen läses filen korrekt: **29 020 kvartar, 2025-10-01 → 2026-07-30, 3 532,6 kWh, 100 % 15-minuterskonsistens.**

<details>
<summary>Så ser E.ON-formatet ut</summary>

```
Anläggnings-id;Tidpunkt för export;Energiprodukt;Starttidpunkt;Sluttidpunkt;Måttenhet
735999114013307011;2026-07-30 12:57:06;Aktiv energi;2025-10-01 00:00:00;2026-07-30 07:00:00;kWh

Starttidpunkt;Sluttidpunkt;Energiriktning;Kvalitet;Kvantitet
2025-10-01 00:00:00;2025-10-01 00:15:00;Produktion;Uppmätt;0,000
2025-10-01 00:15:00;2025-10-01 00:30:00;Produktion;Uppmätt;0,000
```

Den riktiga rubrikraden ligger alltså på rad 4, bakom ett metadatablock och en tomrad.

</details>

## Parsning

- **Hittar rätt rubrikrad.** Varje kandidatrad poängsätts efter hur många följande rader som delar dess kolumnantal och ser ut som data (tolkningsbar tidsstämpel + tal). Den riktiga rubriken följs av tusentals sådana rader, en metadatarubrik av en enda. Lika poäng → tidigaste raden vinner, så vanliga filer med en rubrik på rad 1 påverkas inte.
- **Använder `Sluttidpunkt`** när den finns. Deklarerad längd förblir korrekt över luckor i serien, vilket avstånd mellan starttider inte gör.
- **Filtrerar på `Energiriktning`** så att en blandad export inte summerar Förbrukning i produktionen.
- **Läser enheten från `Måttenhet`** i metadatablocket – E.ON anger den inte i värdekolumnens rubrik.

<details>
<summary>Sommartidsbytet: en kvart som såg ut som 75 minuter</summary>

Vid övergången till sommartid skriver E.ON `2026-03-29 01:45:00 → 2026-03-29 03:00:00` för **en** kvart, eftersom väggklockan hoppar en timme. Tidsstämplarna hanteras som naiv lokaltid, så den raden hade fått 75 minuters längd – fem gånger sin verkliga vikt i de varaktighetsbaserade måtten.

Deklarerade längder som är mer än 2× steget behandlas därför som klockartefakter och kapas till normalsteget. I Johans fil är just den kvarten 0 kWh (klockan två på natten i mars), så siffrorna påverkas inte – men artefakten var reell och testas nu.

Höstens övergång ger i stället fyra dubblerade kvartar (02:00–03:00 inträffar två gånger). Det beteendet är oförändrat och summerar rätt energi.

</details>

## Valfria inställningar → mindre rapport

En tom avgiftsruta betydde tidigare **0 kr**, inte "okänd". Det gav siffror som såg säkra ut men var fel:

- Månadsprognosen visade ett *netto* som i praktiken låtsades att inga fasta avgifter fanns.
- Säkringsråden jämförde nästa/lägre säkrings avgift mot **0 kr/mån**, alltså mot ingenting.

Nu gäller i stället:

| Ifyllt | Vad rapporten innehåller |
|---|---|
| Inget | Produktion, intäkt, negativa priser, månadsprognos **utan** netto |
| Fasta månadsavgifter | + netto efter avgifter |
| Elnätets nuvarande avgift + nästa/lägre säkring | + säkringsråd (upp/ned) |

Prognosen försvinner alltså inte när avgifterna saknas – produktion och ersättning är fortfarande kända och rapporteras. Det är bara nettot som utelämnas, eftersom det inte går att räkna ut. Räcker det med bara elhandelsavgiften så visas nettot ändå.

Fälten är märkta `(valfritt)` i gränssnittet, och hjälptexten säger vad ifyllnad låser upp samt att en tom ruta betyder *okänd avgift, inte 0 kr*.

## Paritet och tester

Speglat i Python-motorn enligt paritetsregeln i `python/CLAUDE.md` (rubrikdetektering i `csv_format_detector_fallback.py`, riktningsfilter i `core/intervals.py`, valfria avgifter i `core/price_analyzer.py`).

- `frontend/scripts/test-analyze.mjs` — **alla 22 test gröna** (Test 21 E.ON-format, Test 22 valfria avgifter är nya)
- `python -m pytest test_intervals.py test_core.py` — **34 gröna** (5 nya)
- `npm run lint` rent, `npm run build` (static export) rent
- Verifierat att båda motorerna ger identiskt resultat på Johans riktiga fil: 29 020 rader, 3 532,6 kWh

<details>
<summary>Regressionskontroll av befintliga format</summary>

Rubrikdetekteringen returnerar rad 0 för vanliga filer, så inget befintligt format ändrar beteende. Explicit testat: den medföljande `exempel-15min.csv` (4 992 rader, oförändrad), vanlig timdata, Excel-vägen (`.xlsx` generisk tabell + "El Rapport"-mallen) och flerfilssammanslagning.

</details>
